### PR TITLE
Machine known id dict

### DIFF
--- a/src/compareJ1939.py
+++ b/src/compareJ1939.py
@@ -25,7 +25,7 @@ def compareKnownIDs(knownIDs: pd.DataFrame, loxamData: pd.DataFrame, set_flag: i
         if(set_flag != 1):
             print(f"Matches: {matches}")
         for match in matches[indexKey]:
-            compare[match][0] = compare[match][0] + 1
+            compare[match][0] += 1
             if key not in compare[match][1]:
                 compare[match][1][key] = 0
             compare[match][1][key] += 1

--- a/src/compareJ1939.py
+++ b/src/compareJ1939.py
@@ -10,35 +10,31 @@ def compareKnownIDs(knownIDs: pd.DataFrame, loxamData: pd.DataFrame, set_flag: i
         indexKey = "ID"
     j1939Machines: list = []
     compare: dict = {}
-    for key in knownIDs[indexKey].unique():
-        compare[key] = [0, {}]
-    for key in loxamData["Machine"].unique():
-        if(set_flag != 1):
-            print(f"Machine: {key}")
+    for id in knownIDs[indexKey].unique():
+        compare[id] = [0, {}]
+    for machine in loxamData["Machine"].unique():
         matches = pd.merge(
             knownIDs,
-            loxamData[loxamData["Machine"] == key],
+            loxamData[loxamData["Machine"] == machine],
             left_on=indexKey,
             right_on="ID",
             how="inner",
         )
-        if(set_flag != 1):
-            print(f"Matches: {matches}")
         for match in matches[indexKey]:
             compare[match][0] += 1
-            if key not in compare[match][1]:
-                compare[match][1][key] = 0
-            compare[match][1][key] += 1
+            if machine not in compare[match][1]:
+                compare[match][1][machine] = 0
+            compare[match][1][machine] += 1
         num_matches = len(matches)
         # 1.2 is not set in stone, but it holds for the current data
         try:
             if (
-                len(loxamData[loxamData["Machine"] == key])
-                / (len(loxamData[loxamData["Machine"] == key]) - num_matches)
+                len(loxamData[loxamData["Machine"] == machine])
+                / (len(loxamData[loxamData["Machine"] == machine]) - num_matches)
                 > 1.2
 
             ):
-                j1939Machines.append(key)
+                j1939Machines.append(machine)
         except ZeroDivisionError:
             pass
 

--- a/src/compareJ1939.py
+++ b/src/compareJ1939.py
@@ -9,7 +9,7 @@ def compareKnownIDs(knownIDs: pd.DataFrame, loxamData: pd.DataFrame) -> list:
     j1939Machines: list = []
     compare: dict = {}
     for key in knownIDs["ID_HEX"].unique():
-        compare[key] = [0, set([])]
+        compare[key] = [0, {}]
     for key in loxamData["Machine"].unique():
         matches = pd.merge(
             knownIDs,
@@ -20,7 +20,9 @@ def compareKnownIDs(knownIDs: pd.DataFrame, loxamData: pd.DataFrame) -> list:
         )
         for match in matches["ID_HEX"]:
             compare[match][0] = compare[match][0] + 1
-            compare[match][1] = compare[match][1].union(set([key]))
+            if key not in compare[match][1]:
+                compare[match][1][key] = 0
+            compare[match][1][key] += 1
         num_matches = len(matches)
         # 1.2 is not set in stone, but it holds for the current data
         if (


### PR DESCRIPTION
extended data analysis, such that we now have pairings of known j1939 ID's and machines - with a collective number of matches and individual matches

> {"Can id: num_of_matches_global , {["machine", num_of_matches],..,.,}}
```
0CF00400 has [3898, {'Kenworth T270': 894, 'Kenworth T660': 3004}] matches
``` 